### PR TITLE
[codex] Add Confluence page move command

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -241,6 +241,13 @@ Markdown으로 Confluence 페이지 생성 및 수정:
 ./bin/conjira --env-file ./local/agent.env replace-section --allow-write --page-id 100002 --heading "배포 계획" --section-markdown-file ./notes/rollout.md
 ```
 
+기존 Confluence 페이지를 다른 부모 페이지 아래로 이동:
+
+```bash
+./bin/conjira --env-file ./local/agent.env move-page --dry-run --page-id 100002 --new-parent-id 100001
+./bin/conjira --env-file ./local/agent.env move-page --allow-write --page-id 100002 --new-parent-id 100001
+```
+
 Confluence나 Jira 쓰기 작업을 먼저 preview:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -241,6 +241,13 @@ Replace one named section on an existing Confluence page:
 ./bin/conjira --env-file ./local/agent.env replace-section --allow-write --page-id 100002 --heading "Rollout plan" --section-markdown-file ./notes/rollout.md
 ```
 
+Move an existing Confluence page under a different parent page:
+
+```bash
+./bin/conjira --env-file ./local/agent.env move-page --dry-run --page-id 100002 --new-parent-id 100001
+./bin/conjira --env-file ./local/agent.env move-page --allow-write --page-id 100002 --new-parent-id 100001
+```
+
 Preview a Confluence or Jira write first:
 
 ```bash

--- a/docs/AGENT_USAGE.md
+++ b/docs/AGENT_USAGE.md
@@ -119,6 +119,13 @@ Preview the same section replacement before writing:
 ./bin/conjira --env-file ./local/agent.env replace-section --dry-run --page-id 100002 --heading "Rollout plan" --section-markdown-file "/path/to/rollout.md"
 ```
 
+Move an existing Confluence page to a new parent:
+
+```bash
+./bin/conjira --env-file ./local/agent.env move-page --dry-run --page-id 100002 --new-parent-id 100001
+./bin/conjira --env-file ./local/agent.env move-page --allow-write --page-id 100002 --new-parent-id 100001
+```
+
 Update an approved Confluence page:
 
 ```bash

--- a/src/conjira_cli/cli.py
+++ b/src/conjira_cli/cli.py
@@ -294,6 +294,15 @@ def _build_parser() -> argparse.ArgumentParser:
     replace_section_body_group.add_argument("--section-markdown")
     replace_section_body_group.add_argument("--section-markdown-file")
 
+    move_page = subparsers.add_parser(
+        "move-page",
+        help="Move an existing Confluence page under a different parent page",
+    )
+    move_page.add_argument("--page-id", required=True)
+    move_page.add_argument("--new-parent-id", required=True)
+    move_page.add_argument("--allow-write", action="store_true")
+    move_page.add_argument("--dry-run", action="store_true")
+
     upload_attachment = subparsers.add_parser(
         "upload-attachment",
         help="Upload or update a Confluence attachment on a page",
@@ -513,6 +522,29 @@ def _confluence_replace_section_preview(
     }
 
 
+def _confluence_move_page_preview(
+    *,
+    page: Dict[str, Any],
+    new_parent_id: str,
+) -> Dict[str, Any]:
+    current_summary = ConfluenceClient.summarize_page(page)
+    ancestors = page.get("ancestors") or []
+    current_parent = ancestors[-1].get("id") if ancestors else None
+    return {
+        "dry_run": True,
+        "product": "confluence",
+        "action": "move-page",
+        "page_id": current_summary.get("id"),
+        "space_key": current_summary.get("space_key"),
+        "source_url": current_summary.get("webui_url"),
+        "title": current_summary.get("title"),
+        "current_version": current_summary.get("version"),
+        "current_parent_id": current_parent,
+        "new_parent_id": new_parent_id,
+        "parent_changed": current_parent != new_parent_id,
+    }
+
+
 def _confluence_attachment_preview(
     *,
     page_id: str,
@@ -674,6 +706,10 @@ def _guidance_for_config_error(message: str) -> list[str]:
         return [
             "Check that the heading text exists exactly once on the live Confluence page before retrying replace-section.",
             "For the first iteration, replace-section is safest on text-first pages with clear heading structure.",
+        ]
+    if "move-page requires different" in lowered:
+        return [
+            "Choose a different parent page before retrying move-page.",
         ]
     if "failed to parse confluence storage html fragment" in lowered:
         return [
@@ -968,6 +1004,37 @@ def _handle_confluence(args: argparse.Namespace) -> Dict[str, Any]:
         payload["action"] = "replace-section"
         payload["heading"] = args.heading
         payload["matched_heading"] = replacement.matched_heading
+        return payload
+    if args.command == "move-page":
+        _require_write_intent(args.allow_write, args.dry_run)
+        _assert_confluence_update_allowed(
+            page_id=args.page_id,
+            allowed_page_ids=settings.allowed_page_ids,
+        )
+        if settings.allowed_parent_ids is not None and args.new_parent_id not in settings.allowed_parent_ids:
+            raise ConfigError(
+                "Write blocked: parent ID {0} is not in CONFLUENCE_ALLOWED_PARENT_IDS.".format(
+                    args.new_parent_id
+                )
+            )
+        page = client.get_page(args.page_id, expand="body.storage,version,space,ancestors")
+        ancestors = page.get("ancestors") or []
+        current_parent = ancestors[-1].get("id") if ancestors else None
+        if current_parent == args.new_parent_id:
+            raise ConfigError("move-page requires different current and new parent IDs.")
+        if args.dry_run:
+            return _confluence_move_page_preview(
+                page=page,
+                new_parent_id=args.new_parent_id,
+            )
+        updated = client.update_page_from_snapshot(
+            page,
+            new_parent_id=args.new_parent_id,
+        )
+        payload = client.summarize_page(updated)
+        payload["action"] = "move-page"
+        payload["previous_parent_id"] = current_parent
+        payload["new_parent_id"] = args.new_parent_id
         return payload
     if args.command == "upload-attachment":
         _require_write_intent(args.allow_write, args.dry_run)

--- a/src/conjira_cli/client.py
+++ b/src/conjira_cli/client.py
@@ -154,6 +154,7 @@ class ConfluenceClient(BaseAtlassianClient):
         new_title: Optional[str] = None,
         new_body_html: Optional[str] = None,
         append_html: Optional[str] = None,
+        new_parent_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         current = self.get_page(page_id, expand="body.storage,version,space")
         return self.update_page_from_snapshot(
@@ -161,6 +162,7 @@ class ConfluenceClient(BaseAtlassianClient):
             new_title=new_title,
             new_body_html=new_body_html,
             append_html=append_html,
+            new_parent_id=new_parent_id,
         )
 
     def update_page_from_snapshot(
@@ -170,6 +172,7 @@ class ConfluenceClient(BaseAtlassianClient):
         new_title: Optional[str] = None,
         new_body_html: Optional[str] = None,
         append_html: Optional[str] = None,
+        new_parent_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         current_body = (((current.get("body") or {}).get("storage") or {}).get("value")) or ""
         updated_body = new_body_html if new_body_html is not None else current_body
@@ -191,6 +194,8 @@ class ConfluenceClient(BaseAtlassianClient):
                 "number": ((current.get("version") or {}).get("number") or 0) + 1,
             },
         }
+        if new_parent_id is not None:
+            payload["ancestors"] = [{"id": new_parent_id}]
         return self.request("PUT", "/rest/api/content/{0}".format(current["id"]), body=payload)
 
     def search(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -373,6 +373,119 @@ class CliTests(unittest.TestCase):
         self.assertEqual(mock_update_page.call_args.args[0]["id"], "12345")
         self.assertIn("<p>Replacement</p>", mock_update_page.call_args.kwargs["new_body_html"])
 
+    def test_handle_confluence_move_page_dry_run_returns_preview(self) -> None:
+        args = SimpleNamespace(
+            command="move-page",
+            base_url=None,
+            token=None,
+            token_file=None,
+            token_keychain_service=None,
+            token_keychain_account=None,
+            timeout=None,
+            env_file=None,
+            page_id="12345",
+            new_parent_id="99999",
+            allow_write=False,
+            dry_run=True,
+        )
+        settings = ConfluenceSettings(
+            base_url="https://confluence.example.com",
+            token="token",
+            timeout_seconds=30,
+        )
+        page = {
+            "id": "12345",
+            "type": "page",
+            "title": "Guide",
+            "space": {"key": "DOCS"},
+            "version": {"number": 7},
+            "ancestors": [{"id": "10000"}],
+            "body": {"storage": {"value": "<p>Body</p>"}},
+            "_links": {
+                "base": "https://confluence.example.com",
+                "webui": "/pages/viewpage.action?pageId=12345",
+            },
+        }
+
+        with mock.patch("conjira_cli.cli.build_confluence_settings", return_value=settings), mock.patch(
+            "conjira_cli.cli.ConfluenceClient.get_page",
+            return_value=page,
+        ) as mock_get_page, mock.patch(
+            "conjira_cli.cli.ConfluenceClient.update_page_from_snapshot"
+        ) as mock_update_page:
+            payload = _handle_confluence(args)
+
+        self.assertTrue(payload["dry_run"])
+        self.assertEqual(payload["action"], "move-page")
+        self.assertEqual(payload["page_id"], "12345")
+        self.assertEqual(payload["current_parent_id"], "10000")
+        self.assertEqual(payload["new_parent_id"], "99999")
+        mock_get_page.assert_called_once_with("12345", expand="body.storage,version,space,ancestors")
+        mock_update_page.assert_not_called()
+
+    def test_handle_confluence_move_page_write_updates_parent(self) -> None:
+        args = SimpleNamespace(
+            command="move-page",
+            base_url=None,
+            token=None,
+            token_file=None,
+            token_keychain_service=None,
+            token_keychain_account=None,
+            timeout=None,
+            env_file=None,
+            page_id="12345",
+            new_parent_id="99999",
+            allow_write=True,
+            dry_run=False,
+        )
+        settings = ConfluenceSettings(
+            base_url="https://confluence.example.com",
+            token="token",
+            timeout_seconds=30,
+        )
+        page = {
+            "id": "12345",
+            "type": "page",
+            "title": "Guide",
+            "space": {"key": "DOCS"},
+            "version": {"number": 7},
+            "ancestors": [{"id": "10000"}],
+            "body": {"storage": {"value": "<p>Body</p>"}},
+            "_links": {
+                "base": "https://confluence.example.com",
+                "webui": "/pages/viewpage.action?pageId=12345",
+            },
+        }
+        updated_summary = {
+            "id": "12345",
+            "type": "page",
+            "status": "current",
+            "title": "Guide",
+            "space": {"key": "DOCS"},
+            "version": {"number": 8},
+            "_links": {
+                "base": "https://confluence.example.com",
+                "webui": "/pages/viewpage.action?pageId=12345",
+            },
+        }
+
+        with mock.patch("conjira_cli.cli.build_confluence_settings", return_value=settings), mock.patch(
+            "conjira_cli.cli.ConfluenceClient.get_page",
+            return_value=page,
+        ) as mock_get_page, mock.patch(
+            "conjira_cli.cli.ConfluenceClient.update_page_from_snapshot",
+            return_value=updated_summary,
+        ) as mock_update_page:
+            payload = _handle_confluence(args)
+
+        self.assertEqual(payload["action"], "move-page")
+        self.assertEqual(payload["previous_parent_id"], "10000")
+        self.assertEqual(payload["new_parent_id"], "99999")
+        mock_get_page.assert_called_once_with("12345", expand="body.storage,version,space,ancestors")
+        mock_update_page.assert_called_once()
+        self.assertEqual(mock_update_page.call_args.args[0]["id"], "12345")
+        self.assertEqual(mock_update_page.call_args.kwargs["new_parent_id"], "99999")
+
     def test_build_error_payload_adds_replace_section_guidance(self) -> None:
         payload = _build_error_payload(
             ConfigError('replace-section target heading "Install" was not found.')
@@ -380,6 +493,14 @@ class CliTests(unittest.TestCase):
 
         self.assertEqual(payload["error_type"], "ConfigError")
         self.assertTrue(any("heading" in item.lower() for item in payload["guidance"]))
+
+    def test_build_error_payload_adds_move_page_guidance(self) -> None:
+        payload = _build_error_payload(
+            ConfigError("move-page requires different current and new parent IDs.")
+        )
+
+        self.assertEqual(payload["error_type"], "ConfigError")
+        self.assertTrue(any("different parent" in item.lower() for item in payload["guidance"]))
 
     def test_handle_jira_add_comment_dry_run_returns_preview(self) -> None:
         args = SimpleNamespace(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -29,6 +29,27 @@ class ClientTests(unittest.TestCase):
         self.assertEqual(payload["version"]["number"], 8)
         self.assertEqual(payload["body"]["storage"]["value"], "<p>New body</p>")
 
+    def test_update_page_from_snapshot_can_change_parent(self) -> None:
+        client = ConfluenceClient(base_url="https://confluence.example.com", token="token")
+        snapshot = {
+            "id": "123",
+            "type": "page",
+            "title": "Demo",
+            "space": {"key": "TEST"},
+            "version": {"number": 7},
+            "body": {"storage": {"value": "<p>Old body</p>"}},
+        }
+
+        with mock.patch.object(client, "request", return_value={"id": "123"}) as mock_request:
+            client.update_page_from_snapshot(
+                snapshot,
+                new_parent_id="900",
+            )
+
+        payload = mock_request.call_args.kwargs["body"]
+        self.assertEqual(payload["ancestors"], [{"id": "900"}])
+        self.assertEqual(payload["version"]["number"], 8)
+
     def test_summarize_page_extracts_core_fields(self) -> None:
         page = {
             "id": "123",


### PR DESCRIPTION
## Summary
- add a `move-page` command for Confluence page parent reassignment
- add `--dry-run` preview for page move operations
- document the new workflow and cover it with tests

## Testing
- PYTHONPATH=src python3 -m unittest discover -s tests -v
- dry-run smoke test against internal Confluence env