### PR TITLE
[codex] Add Confluence page tree export

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -215,6 +215,12 @@ Confluence 페이지를 Markdown으로 export:
 ./bin/conjira --env-file ./local/agent.env export-page-md --page-id 123456 --output-dir "/path/to/work-folder"
 ```
 
+Confluence 페이지 트리를 중첩 폴더 구조로 export:
+
+```bash
+./bin/conjira --env-file ./local/agent.env export-tree-md --page-id 123456 --output-dir "/path/to/work-folder"
+```
+
 Confluence 인라인 코멘트 스레드 export:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -215,6 +215,12 @@ Export a Confluence page to Markdown:
 ./bin/conjira --env-file ./local/agent.env export-page-md --page-id 123456 --output-dir "/path/to/work-folder"
 ```
 
+Export a Confluence page tree to nested Markdown folders:
+
+```bash
+./bin/conjira --env-file ./local/agent.env export-tree-md --page-id 123456 --output-dir "/path/to/work-folder"
+```
+
 Export grouped inline comment threads:
 
 ```bash

--- a/docs/AGENT_USAGE.md
+++ b/docs/AGENT_USAGE.md
@@ -59,6 +59,12 @@ Export to a known work folder:
 ./bin/conjira --env-file ./local/agent.env export-page-md --page-id 123456 --output-dir "/path/to/work-folder"
 ```
 
+Export a Confluence page tree to nested work folders:
+
+```bash
+./bin/conjira --env-file ./local/agent.env export-tree-md --page-id 123456 --output-dir "/path/to/work-folder"
+```
+
 Export to staging under `local/exports`:
 
 ```bash

--- a/src/conjira_cli/cli.py
+++ b/src/conjira_cli/cli.py
@@ -24,6 +24,7 @@ from conjira_cli.inline_comments import render_inline_comment_summary_markdown
 from conjira_cli.markdown_export import MarkdownExporter
 from conjira_cli.markdown_import import markdown_to_storage_html
 from conjira_cli.section_edit import SectionEditError, replace_section_html
+from conjira_cli.tree_export import export_page_tree, sanitize_path_component
 
 
 def _read_text_arg(raw_text: Optional[str], file_path: Optional[str]) -> str:
@@ -142,6 +143,13 @@ def _read_export_metadata(path: Path) -> Dict[str, Any]:
     }
 
 
+def _page_export_payload(page: Dict[str, Any]) -> Dict[str, Any]:
+    payload = ConfluenceClient.summarize_page(page)
+    payload["body_html"] = (((page.get("body") or {}).get("storage") or {}).get("value")) or ""
+    payload["ancestors"] = page.get("ancestors") or []
+    return payload
+
+
 def _default_export_staging_dir() -> Path:
     return Path(__file__).resolve().parents[2] / "local" / "exports"
 
@@ -211,6 +219,14 @@ def _build_parser() -> argparse.ArgumentParser:
     export_page_md.add_argument("--output-dir")
     export_page_md.add_argument("--filename")
     export_page_md.add_argument("--staging-local", action="store_true")
+
+    export_tree_md = subparsers.add_parser(
+        "export-tree-md",
+        help="Export a Confluence page tree to nested Markdown folders",
+    )
+    export_tree_md.add_argument("--page-id", required=True)
+    export_tree_md.add_argument("--output-dir")
+    export_tree_md.add_argument("--staging-local", action="store_true")
 
     check_page_md_freshness = subparsers.add_parser(
         "check-page-md-freshness",
@@ -773,8 +789,7 @@ def _handle_confluence(args: argparse.Namespace) -> Dict[str, Any]:
         return payload
     if args.command == "export-page-md":
         page = client.get_page(args.page_id, expand="body.storage,version,space")
-        payload = client.summarize_page(page)
-        payload["body_html"] = (((page.get("body") or {}).get("storage") or {}).get("value")) or ""
+        payload = _page_export_payload(page)
         exporter = MarkdownExporter(base_url=settings.base_url, page_id=args.page_id)
         markdown = exporter.convert_page(payload)
         output_path = _resolve_export_output_path(
@@ -794,6 +809,59 @@ def _handle_confluence(args: argparse.Namespace) -> Dict[str, Any]:
             "output_file": str(output_path),
             "source_url": payload["webui_url"],
             "used_staging_local": str(output_path).startswith(
+                str((Path(settings.export_staging_dir) if settings.export_staging_dir else _default_export_staging_dir()))
+            ),
+        }
+    if args.command == "export-tree-md":
+        root_page = client.get_page(args.page_id, expand="body.storage,version,space,ancestors")
+        root_payload = _page_export_payload(root_page)
+        output_base = (
+            Path(args.output_dir)
+            if args.output_dir
+            else (
+                Path(settings.export_staging_dir)
+                if args.staging_local and settings.export_staging_dir
+                else (
+                    _default_export_staging_dir()
+                    if args.staging_local
+                    else (
+                        Path(settings.export_default_dir)
+                        if settings.export_default_dir
+                        else None
+                    )
+                )
+            )
+        )
+        if output_base is None:
+            raise ConfigError(
+                "Tree export requires --output-dir, or CONFLUENCE_EXPORT_DEFAULT_DIR, or --staging-local."
+            )
+        exported = export_page_tree(
+            root_page=root_payload,
+            output_dir=output_base,
+            fetch_page=lambda page_id: _page_export_payload(
+                client.get_page(page_id, expand="body.storage,version,space,ancestors")
+            ),
+            list_child_pages=client.list_child_pages,
+            base_url=settings.base_url,
+        )
+        root_dir = str(output_base / sanitize_path_component(root_payload["title"] or "Untitled"))
+        return {
+            "page_id": args.page_id,
+            "title": root_payload["title"],
+            "root_output_dir": root_dir,
+            "exported_count": len(exported),
+            "exported_pages": [
+                {
+                    "page_id": item.page_id,
+                    "title": item.title,
+                    "output_file": item.output_file,
+                    "source_url": item.source_url,
+                    "parent_page_id": item.parent_page_id,
+                }
+                for item in exported
+            ],
+            "used_staging_local": str(output_base).startswith(
                 str((Path(settings.export_staging_dir) if settings.export_staging_dir else _default_export_staging_dir()))
             ),
         }

--- a/src/conjira_cli/client.py
+++ b/src/conjira_cli/client.py
@@ -124,6 +124,42 @@ class ConfluenceClient(BaseAtlassianClient):
         query = {"expand": expand} if expand else None
         return self.request("GET", "/rest/api/content/{0}".format(page_id), query=query)
 
+    def get_child_pages(
+        self,
+        page_id: str,
+        *,
+        limit: int = 200,
+        start: int = 0,
+    ) -> Dict[str, Any]:
+        return self.request(
+            "GET",
+            "/rest/api/content/{0}/child/page".format(page_id),
+            query={"limit": limit, "start": start},
+        )
+
+    def list_child_pages(
+        self,
+        page_id: str,
+        *,
+        limit: int = 200,
+    ) -> list[Dict[str, Any]]:
+        pages: list[Dict[str, Any]] = []
+        start = 0
+
+        while True:
+            result = self.get_child_pages(page_id, limit=limit, start=start)
+            batch = result.get("results", []) if isinstance(result, dict) else []
+            if not batch:
+                break
+            pages.extend(batch)
+
+            batch_size = len(batch)
+            if batch_size < limit:
+                break
+            start += batch_size
+
+        return pages
+
     def create_page(
         self,
         *,

--- a/src/conjira_cli/markdown_export.py
+++ b/src/conjira_cli/markdown_export.py
@@ -111,6 +111,7 @@ class MarkdownExporter:
         title = page.get("title") or "Untitled"
         source_url = page.get("webui_url") or ""
         version = page.get("version")
+        parent_page_id = page.get("parent_page_id")
         body_html = page.get("body_html") or ""
         body_md = self.convert_fragment(body_html)
 
@@ -119,6 +120,11 @@ class MarkdownExporter:
             f'title: "{title.replace(chr(34), chr(39))}"',
             f"confluence_page_id: {self.page_id}",
             f"confluence_version: {version}",
+        ]
+        if parent_page_id:
+            parts.append(f"confluence_parent_page_id: {parent_page_id}")
+        parts.extend(
+            [
             f"source_url: {source_url}",
             f"exported_at: {datetime.now().astimezone().isoformat(timespec='seconds')}",
             "---",
@@ -129,7 +135,8 @@ class MarkdownExporter:
             "",
             body_md.strip(),
             "",
-        ]
+            ]
+        )
         return "\n".join(parts)
 
     def convert_fragment(self, body_html: str) -> str:

--- a/src/conjira_cli/tree_export.py
+++ b/src/conjira_cli/tree_export.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+from conjira_cli.markdown_export import MarkdownExporter
+
+
+def sanitize_path_component(value: str) -> str:
+    sanitized = "".join(
+        "_" if char in '<>:"/\\|?*' else char
+        for char in value
+    )
+    sanitized = sanitized.strip().rstrip(".")
+    sanitized = " ".join(sanitized.split())
+    return sanitized or "untitled"
+
+
+@dataclass
+class ExportedTreePage:
+    page_id: str
+    title: str
+    output_file: str
+    source_url: str | None
+    parent_page_id: str | None
+
+
+def export_page_tree(
+    *,
+    root_page: dict[str, Any],
+    output_dir: Path,
+    fetch_page: Callable[[str], dict[str, Any]],
+    list_child_pages: Callable[[str], Iterable[dict[str, Any]]],
+    base_url: str,
+) -> list[ExportedTreePage]:
+    exported: list[ExportedTreePage] = []
+
+    def export_node(page: dict[str, Any], parent_dir: Path) -> None:
+        title = page.get("title") or "Untitled"
+        page_dir = parent_dir / sanitize_path_component(title)
+        page_dir.mkdir(parents=True, exist_ok=True)
+
+        page_id = str(page["id"])
+        ancestors = page.get("ancestors") or []
+        parent_page_id = ancestors[-1].get("id") if ancestors else None
+
+        exporter = MarkdownExporter(base_url=base_url, page_id=page_id)
+        markdown = exporter.convert_page(
+            {
+                **page,
+                "parent_page_id": parent_page_id,
+            }
+        )
+        output_file = page_dir / "index.md"
+        output_file.write_text(markdown, encoding="utf-8")
+
+        exported.append(
+            ExportedTreePage(
+                page_id=page_id,
+                title=title,
+                output_file=str(output_file),
+                source_url=page.get("webui_url"),
+                parent_page_id=parent_page_id,
+            )
+        )
+
+        for child in list_child_pages(page_id):
+            child_page = fetch_page(str(child["id"]))
+            export_node(child_page, page_dir)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    export_node(root_page, output_dir)
+    return exported

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -179,6 +179,67 @@ class CliTests(unittest.TestCase):
         self.assertEqual(payload["body_source"], "markdown")
         self.assertIn("Demo", payload["body_preview"])
 
+    def test_handle_confluence_export_tree_md_returns_summary(self) -> None:
+        args = SimpleNamespace(
+            command="export-tree-md",
+            base_url=None,
+            token=None,
+            token_file=None,
+            token_keychain_service=None,
+            token_keychain_account=None,
+            timeout=None,
+            env_file=None,
+            page_id="12345",
+            output_dir=None,
+            staging_local=True,
+        )
+        settings = ConfluenceSettings(
+            base_url="https://confluence.example.com",
+            token="token",
+            timeout_seconds=30,
+            export_staging_dir="/tmp/conjira-staging",
+        )
+        root_page = {
+            "id": "12345",
+            "type": "page",
+            "title": "Guide",
+            "space": {"key": "DOCS"},
+            "version": {"number": 7},
+            "ancestors": [],
+            "body": {"storage": {"value": "<p>Body</p>"}},
+            "_links": {
+                "base": "https://confluence.example.com",
+                "webui": "/pages/viewpage.action?pageId=12345",
+            },
+        }
+
+        exported = [
+            SimpleNamespace(
+                page_id="12345",
+                title="Guide",
+                output_file="/tmp/conjira-staging/Guide/index.md",
+                source_url="https://confluence.example.com/pages/12345",
+                parent_page_id=None,
+            )
+        ]
+
+        with mock.patch("conjira_cli.cli.build_confluence_settings", return_value=settings), mock.patch(
+            "conjira_cli.cli.ConfluenceClient.get_page",
+            return_value=root_page,
+        ) as mock_get_page, mock.patch(
+            "conjira_cli.cli.export_page_tree",
+            return_value=exported,
+        ) as mock_export_tree:
+            payload = _handle_confluence(args)
+
+        self.assertEqual(payload["page_id"], "12345")
+        self.assertEqual(payload["title"], "Guide")
+        self.assertEqual(payload["exported_count"], 1)
+        self.assertEqual(payload["root_output_dir"], "/tmp/conjira-staging/Guide")
+        self.assertTrue(payload["used_staging_local"])
+        mock_get_page.assert_called_once_with("12345", expand="body.storage,version,space,ancestors")
+        mock_export_tree.assert_called_once()
+
     def test_handle_confluence_update_page_dry_run_uses_live_page_without_write(self) -> None:
         args = SimpleNamespace(
             command="update-page",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -134,3 +134,19 @@ class ClientTests(unittest.TestCase):
 
         self.assertEqual([comment["id"] for comment in comments], ["1", "2", "3"])
         self.assertEqual(mock_get_inline_comments.call_count, 2)
+
+    def test_list_child_pages_fetches_all_pages(self) -> None:
+        client = ConfluenceClient(base_url="https://confluence.example.com", token="token")
+
+        with mock.patch.object(
+            client,
+            "get_child_pages",
+            side_effect=[
+                {"results": [{"id": "1"}, {"id": "2"}]},
+                {"results": [{"id": "3"}]},
+            ],
+        ) as mock_get_child_pages:
+            pages = client.list_child_pages("123", limit=2)
+
+        self.assertEqual([page["id"] for page in pages], ["1", "2", "3"])
+        self.assertEqual(mock_get_child_pages.call_count, 2)

--- a/tests/test_markdown_export.py
+++ b/tests/test_markdown_export.py
@@ -23,6 +23,21 @@ class MarkdownExportTests(unittest.TestCase):
         self.assertIn("B", result)
         self.assertIn("![demo.png](https://confluence.example.com/download/attachments/123/demo.png)", result)
 
+    def test_convert_page_includes_parent_page_id_when_present(self) -> None:
+        exporter = MarkdownExporter(base_url="https://confluence.example.com", page_id="123")
+
+        result = exporter.convert_page(
+            {
+                "title": "Demo",
+                "version": 7,
+                "webui_url": "https://confluence.example.com/pages/123",
+                "body_html": "<p>Hello</p>",
+                "parent_page_id": "100",
+            }
+        )
+
+        self.assertIn("confluence_parent_page_id: 100", result)
+
     def test_structured_table_renders_as_sections(self) -> None:
         exporter = MarkdownExporter(base_url="https://confluence.example.com", page_id="123")
         html = (

--- a/tests/test_tree_export.py
+++ b/tests/test_tree_export.py
@@ -1,0 +1,56 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from conjira_cli.tree_export import export_page_tree, sanitize_path_component
+
+
+class TreeExportTests(unittest.TestCase):
+    def test_sanitize_path_component_replaces_invalid_chars(self) -> None:
+        self.assertEqual(sanitize_path_component('A/B:C*D?'), 'A_B_C_D_')
+
+    def test_export_page_tree_writes_nested_index_files(self) -> None:
+        root_page = {
+            "id": "1",
+            "title": "Root Page",
+            "version": 1,
+            "webui_url": "https://confluence.example.com/pages/1",
+            "body_html": "<p>Root body</p>",
+            "ancestors": [],
+        }
+        child_page = {
+            "id": "2",
+            "title": "Child Page",
+            "version": 2,
+            "webui_url": "https://confluence.example.com/pages/2",
+            "body_html": "<p>Child body</p>",
+            "ancestors": [{"id": "1"}],
+        }
+
+        pages = {
+            "1": root_page,
+            "2": child_page,
+        }
+        children = {
+            "1": [{"id": "2", "title": "Child Page"}],
+            "2": [],
+        }
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            exported = export_page_tree(
+                root_page=root_page,
+                output_dir=Path(tmp_dir),
+                fetch_page=lambda page_id: pages[page_id],
+                list_child_pages=lambda page_id: children[page_id],
+                base_url="https://confluence.example.com",
+            )
+
+            root_index = Path(tmp_dir) / "Root Page" / "index.md"
+            child_index = Path(tmp_dir) / "Root Page" / "Child Page" / "index.md"
+
+            self.assertTrue(root_index.exists())
+            self.assertTrue(child_index.exists())
+            self.assertIn("confluence_page_id: 1", root_index.read_text(encoding="utf-8"))
+            self.assertIn("confluence_page_id: 2", child_index.read_text(encoding="utf-8"))
+            self.assertIn("confluence_parent_page_id: 1", child_index.read_text(encoding="utf-8"))
+            self.assertEqual(len(exported), 2)


### PR DESCRIPTION
## Summary
- add `export-tree-md` for nested Confluence page export
- preserve page hierarchy as local folders with `index.md` files
- include parent page metadata in exported frontmatter and document the workflow

## Testing
- PYTHONPATH=src python3 -m unittest discover -s tests -v
- internal smoke test with `export-tree-md` against a real Confluence page tree