### PR TITLE
Add smart hub-page handling for Confluence reads

### DIFF
--- a/src/conjira_cli/cli.py
+++ b/src/conjira_cli/cli.py
@@ -129,6 +129,62 @@ def _preview_html(value: Optional[str], limit: int = 240) -> Optional[str]:
     return _preview_text(preview, limit=limit)
 
 
+def _page_body_html(page: Dict[str, Any]) -> str:
+    return (((page.get("body") or {}).get("storage") or {}).get("value")) or ""
+
+
+def _is_effectively_empty_body(body_html: Optional[str]) -> bool:
+    if not body_html:
+        return True
+    normalized = body_html.replace("\xa0", " ").replace("&nbsp;", " ")
+    normalized = re.sub(r"<!--.*?-->", "", normalized, flags=re.DOTALL)
+    normalized = re.sub(r"<p>\s*(<br\s*/?>)?\s*</p>", "", normalized, flags=re.IGNORECASE)
+    normalized = re.sub(r"<br\s*/?>", "", normalized, flags=re.IGNORECASE)
+    normalized = re.sub(r"\s+", "", normalized)
+    return normalized == ""
+
+
+def _summarize_child_pages(child_pages: list[Dict[str, Any]]) -> list[Dict[str, Any]]:
+    return [ConfluenceClient.summarize_page(page) for page in child_pages]
+
+
+def _fallback_confluence_page_url(page: Dict[str, Any], page_id: Optional[str]) -> Optional[str]:
+    if not page_id:
+        return None
+    base_url = ((page.get("_links") or {}).get("base")) or ""
+    if not base_url:
+        return None
+    return "{0}/pages/viewpage.action?pageId={1}".format(base_url.rstrip("/"), page_id)
+
+
+def _page_navigation_payload(
+    *,
+    page: Dict[str, Any],
+    child_pages: list[Dict[str, Any]],
+) -> Dict[str, Any]:
+    body_html = _page_body_html(page)
+    body_is_effectively_empty = _is_effectively_empty_body(body_html)
+    child_summaries = _summarize_child_pages(child_pages)
+    for summary in child_summaries:
+        if not summary.get("webui_url"):
+            summary["webui_url"] = _fallback_confluence_page_url(page, summary.get("id"))
+    page_kind = "hub" if body_is_effectively_empty and child_summaries else "content"
+
+    payload: Dict[str, Any] = {
+        "page_kind": page_kind,
+        "body_is_effectively_empty": body_is_effectively_empty,
+        "child_count": len(child_summaries),
+    }
+    if child_summaries:
+        payload["children"] = child_summaries
+    if page_kind == "hub":
+        payload["read_hint"] = (
+            "This page behaves like a hub/index page. Read the listed child pages or use "
+            "`export-tree-md` for the full hierarchy."
+        )
+    return payload
+
+
 def _sanitize_markdown_filename(title: str) -> str:
     sanitized = "".join(
         "_" if char in '<>:"/\\|?*' else char
@@ -181,7 +237,7 @@ def _read_export_metadata(path: Path) -> Dict[str, Any]:
 
 def _page_export_payload(page: Dict[str, Any]) -> Dict[str, Any]:
     payload = ConfluenceClient.summarize_page(page)
-    payload["body_html"] = (((page.get("body") or {}).get("storage") or {}).get("value")) or ""
+    payload["body_html"] = _page_body_html(page)
     payload["ancestors"] = page.get("ancestors") or []
     return payload
 
@@ -822,14 +878,19 @@ def _handle_confluence(args: argparse.Namespace) -> Dict[str, Any]:
     if args.command == "auth-check":
         return client.auth_check()
     if args.command == "get-page":
-        page = client.get_page(args.page_id, expand=args.expand)
+        expand = _merge_csv_fields(args.expand, ["body.storage", "version", "space"])
+        page = client.get_page(args.page_id, expand=expand)
+        child_pages = client.list_child_pages(args.page_id)
         payload = client.summarize_page(page)
+        payload.update(_page_navigation_payload(page=page, child_pages=child_pages))
         if args.expand and "body.storage" in args.expand:
-            payload["body_html"] = (((page.get("body") or {}).get("storage") or {}).get("value"))
+            payload["body_html"] = _page_body_html(page)
         return payload
     if args.command == "export-page-md":
         page = client.get_page(args.page_id, expand="body.storage,version,space")
+        child_pages = client.list_child_pages(args.page_id)
         payload = _page_export_payload(page)
+        payload.update(_page_navigation_payload(page=page, child_pages=child_pages))
         exporter = MarkdownExporter(
             base_url=settings.base_url,
             page_id=args.page_id,
@@ -852,6 +913,9 @@ def _handle_confluence(args: argparse.Namespace) -> Dict[str, Any]:
             "title": payload["title"],
             "output_file": str(output_path),
             "source_url": payload["webui_url"],
+            "page_kind": payload["page_kind"],
+            "child_count": payload["child_count"],
+            "hub_generated": payload["page_kind"] == "hub",
             "used_staging_local": str(output_path).startswith(
                 str((Path(settings.export_staging_dir) if settings.export_staging_dir else _default_export_staging_dir()))
             ),

--- a/src/conjira_cli/markdown_export.py
+++ b/src/conjira_cli/markdown_export.py
@@ -113,6 +113,10 @@ def _normalize_table_header(value: str) -> str:
     return value
 
 
+def _escape_table_cell(value: str) -> str:
+    return value.replace("|", "\\|").strip()
+
+
 @dataclass
 class MarkdownExporter:
     base_url: str
@@ -124,8 +128,14 @@ class MarkdownExporter:
         source_url = page.get("webui_url") or ""
         version = page.get("version")
         parent_page_id = page.get("parent_page_id")
+        page_kind = page.get("page_kind")
+        child_count = page.get("child_count")
         body_html = page.get("body_html") or ""
-        body_md = self.convert_fragment(body_html)
+        children = page.get("children") or []
+        if page_kind == "hub" and children:
+            body_md = self._render_hub_page(children)
+        else:
+            body_md = self.convert_fragment(body_html)
 
         parts = [
             "---",
@@ -135,6 +145,10 @@ class MarkdownExporter:
         ]
         if parent_page_id:
             parts.append(f"confluence_parent_page_id: {parent_page_id}")
+        if page_kind:
+            parts.append(f"confluence_page_kind: {page_kind}")
+        if child_count:
+            parts.append(f"confluence_child_count: {child_count}")
         parts.extend(
             [
             f"source_url: {source_url}",
@@ -150,6 +164,25 @@ class MarkdownExporter:
             ]
         )
         return "\n".join(parts)
+
+    def _render_hub_page(self, children: list[dict[str, Any]]) -> str:
+        lines = [
+            "> [!INFO] This is a Confluence hub/index page.",
+            "> The main content lives in the child pages listed below.",
+            "",
+            "## Child pages",
+            "",
+            "| Title | Page ID | Link |",
+            "| --- | --- | --- |",
+        ]
+        for child in children:
+            title = _escape_table_cell(child.get("title") or "Untitled")
+            page_id = _escape_table_cell(str(child.get("id") or ""))
+            url = child.get("webui_url") or ""
+            link = f"[Open]({url})" if url else ""
+            lines.append(f"| {title} | {page_id} | {link} |")
+        lines.append("")
+        return "\n".join(lines)
 
     def convert_fragment(self, body_html: str) -> str:
         wrapped = (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -240,6 +240,142 @@ class CliTests(unittest.TestCase):
         mock_get_page.assert_called_once_with("12345", expand="body.storage,version,space,ancestors")
         mock_export_tree.assert_called_once()
 
+    def test_handle_confluence_get_page_marks_hub_and_lists_children(self) -> None:
+        args = SimpleNamespace(
+            command="get-page",
+            base_url=None,
+            token=None,
+            token_file=None,
+            token_keychain_service=None,
+            token_keychain_account=None,
+            timeout=None,
+            env_file=None,
+            page_id="12345",
+            expand="body.storage",
+        )
+        settings = ConfluenceSettings(
+            base_url="https://confluence.example.com",
+            token="token",
+            timeout_seconds=30,
+        )
+        page = {
+            "id": "12345",
+            "type": "page",
+            "status": "current",
+            "title": "AI 메시지 상세기획",
+            "space": {"key": "DOCS"},
+            "version": {"number": 7},
+            "body": {"storage": {"value": "<p><br/></p>"}},
+            "_links": {
+                "base": "https://confluence.example.com",
+                "webui": "/pages/viewpage.action?pageId=12345",
+            },
+        }
+        child_pages = [
+            {
+                "id": "20001",
+                "type": "page",
+                "status": "current",
+                "title": "메시지 AI 제안",
+            }
+        ]
+
+        with mock.patch("conjira_cli.cli.build_confluence_settings", return_value=settings), mock.patch(
+            "conjira_cli.cli.ConfluenceClient.get_page",
+            return_value=page,
+        ) as mock_get_page, mock.patch(
+            "conjira_cli.cli.ConfluenceClient.list_child_pages",
+            return_value=child_pages,
+        ) as mock_list_child_pages:
+            payload = _handle_confluence(args)
+
+        self.assertEqual(payload["page_kind"], "hub")
+        self.assertTrue(payload["body_is_effectively_empty"])
+        self.assertEqual(payload["child_count"], 1)
+        self.assertEqual(payload["children"][0]["id"], "20001")
+        self.assertEqual(
+            payload["children"][0]["webui_url"],
+            "https://confluence.example.com/pages/viewpage.action?pageId=20001",
+        )
+        self.assertIn("hub/index page", payload["read_hint"])
+        self.assertEqual(payload["body_html"], "<p><br/></p>")
+        mock_get_page.assert_called_once_with("12345", expand="body.storage,version,space")
+        mock_list_child_pages.assert_called_once_with("12345")
+
+    def test_handle_confluence_export_page_md_generates_hub_markdown(self) -> None:
+        args = SimpleNamespace(
+            command="export-page-md",
+            base_url=None,
+            token=None,
+            token_file=None,
+            token_keychain_service=None,
+            token_keychain_account=None,
+            timeout=None,
+            env_file=None,
+            page_id="12345",
+            output_file=None,
+            output_dir=None,
+            filename=None,
+            staging_local=True,
+        )
+        settings = ConfluenceSettings(
+            base_url="https://confluence.example.com",
+            token="token",
+            timeout_seconds=30,
+            export_staging_dir="/tmp/conjira-staging",
+        )
+        page = {
+            "id": "12345",
+            "type": "page",
+            "status": "current",
+            "title": "AI 메시지 상세기획",
+            "space": {"key": "DOCS"},
+            "version": {"number": 7},
+            "body": {"storage": {"value": ""}},
+            "_links": {
+                "base": "https://confluence.example.com",
+                "webui": "/pages/viewpage.action?pageId=12345",
+            },
+        }
+        child_pages = [
+            {
+                "id": "20001",
+                "type": "page",
+                "status": "current",
+                "title": "메시지 AI 제안",
+                "space": {"key": "DOCS"},
+                "version": {"number": 3},
+                "_links": {
+                    "base": "https://confluence.example.com",
+                    "webui": "/pages/viewpage.action?pageId=20001",
+                },
+            }
+        ]
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            settings.export_staging_dir = tmp_dir
+            with mock.patch("conjira_cli.cli.build_confluence_settings", return_value=settings), mock.patch(
+                "conjira_cli.cli.ConfluenceClient.get_page",
+                return_value=page,
+            ) as mock_get_page, mock.patch(
+                "conjira_cli.cli.ConfluenceClient.list_child_pages",
+                return_value=child_pages,
+            ) as mock_list_child_pages:
+                payload = _handle_confluence(args)
+
+            output_file = Path(payload["output_file"])
+            markdown = output_file.read_text(encoding="utf-8")
+
+        self.assertEqual(payload["page_kind"], "hub")
+        self.assertEqual(payload["child_count"], 1)
+        self.assertTrue(payload["hub_generated"])
+        self.assertIn("confluence_page_kind: hub", markdown)
+        self.assertIn("confluence_child_count: 1", markdown)
+        self.assertIn("> [!INFO] This is a Confluence hub/index page.", markdown)
+        self.assertIn("| 메시지 AI 제안 | 20001 |", markdown)
+        mock_get_page.assert_called_once_with("12345", expand="body.storage,version,space")
+        mock_list_child_pages.assert_called_once_with("12345")
+
     def test_handle_confluence_update_page_dry_run_uses_live_page_without_write(self) -> None:
         args = SimpleNamespace(
             command="update-page",

--- a/tests/test_markdown_export.py
+++ b/tests/test_markdown_export.py
@@ -38,6 +38,38 @@ class MarkdownExportTests(unittest.TestCase):
 
         self.assertIn("confluence_parent_page_id: 100", result)
 
+    def test_convert_page_renders_hub_children_as_index_content(self) -> None:
+        exporter = MarkdownExporter(base_url="https://confluence.example.com", page_id="123")
+
+        result = exporter.convert_page(
+            {
+                "title": "상세기획 루트",
+                "version": 7,
+                "webui_url": "https://confluence.example.com/pages/123",
+                "body_html": "",
+                "page_kind": "hub",
+                "child_count": 2,
+                "children": [
+                    {
+                        "id": "20001",
+                        "title": "메시지 AI 제안",
+                        "webui_url": "https://confluence.example.com/pages/20001",
+                    },
+                    {
+                        "id": "20002",
+                        "title": "메시지 요약",
+                        "webui_url": "https://confluence.example.com/pages/20002",
+                    },
+                ],
+            }
+        )
+
+        self.assertIn("confluence_page_kind: hub", result)
+        self.assertIn("confluence_child_count: 2", result)
+        self.assertIn("## Child pages", result)
+        self.assertIn("| 메시지 AI 제안 | 20001 | [Open](https://confluence.example.com/pages/20001) |", result)
+        self.assertIn("| 메시지 요약 | 20002 | [Open](https://confluence.example.com/pages/20002) |", result)
+
     def test_structured_table_renders_as_sections(self) -> None:
         exporter = MarkdownExporter(base_url="https://confluence.example.com", page_id="123")
         html = (


### PR DESCRIPTION
## Summary
- detect hub/index-style Confluence pages when the root body is effectively empty but child pages exist
- include child page metadata and read hints in `get-page` responses
- export hub pages as useful Markdown index files instead of blank bodies

## Testing
- PYTHONPATH=src python3 -m unittest discover -s tests -v
- python3 -m compileall src/conjira_cli
- PYTHONPATH=src ./bin/conjira --env-file "/Users/daehwan/Library/Mobile Documents/iCloud~md~obsidian/Documents/Vault/500. 프로젝트/tde-confluence-cli/local/agent.env" --output json get-page --page-id 919784088 --expand body.storage
- PYTHONPATH=src ./bin/conjira --env-file "/Users/daehwan/Library/Mobile Documents/iCloud~md~obsidian/Documents/Vault/500. 프로젝트/tde-confluence-cli/local/agent.env" export-page-md --page-id 919784088 --output-dir /tmp/conjira_hub_smoke

Closes #50