### PR TITLE
[codex] Add insert-after-heading partial edit command

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -309,6 +309,12 @@ conjira --env-file ./local/agent.env update-page --allow-write --page-id 100002 
 conjira --env-file ./local/agent.env replace-section --allow-write --page-id 100002 --heading "배포 계획" --section-markdown-file ./notes/rollout.md
 ```
 
+특정 heading 바로 아래에 새 콘텐츠 삽입:
+
+```bash
+conjira --env-file ./local/agent.env insert-after-heading --dry-run --page-id 100002 --heading "배포 계획" --insert-markdown-file ./notes/rollout-intro.md
+```
+
 기존 Confluence 페이지를 다른 부모 페이지 아래로 이동:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -309,6 +309,12 @@ Replace one named section on an existing Confluence page:
 conjira --env-file ./local/agent.env replace-section --allow-write --page-id 100002 --heading "Rollout plan" --section-markdown-file ./notes/rollout.md
 ```
 
+Insert new content immediately after a named heading:
+
+```bash
+conjira --env-file ./local/agent.env insert-after-heading --dry-run --page-id 100002 --heading "Rollout plan" --insert-markdown-file ./notes/rollout-intro.md
+```
+
 Move an existing Confluence page under a different parent page:
 
 ```bash

--- a/docs/AGENT_USAGE.md
+++ b/docs/AGENT_USAGE.md
@@ -119,6 +119,12 @@ Replace a named section under an existing Confluence heading:
 ./bin/conjira --env-file ./local/agent.env replace-section --allow-write --page-id 100002 --heading "Rollout plan" --section-markdown-file "/path/to/rollout.md"
 ```
 
+Insert content immediately after an existing Confluence heading:
+
+```bash
+./bin/conjira --env-file ./local/agent.env insert-after-heading --dry-run --page-id 100002 --heading "Rollout plan" --insert-markdown-file "/path/to/rollout-intro.md"
+```
+
 Preview the same section replacement before writing:
 
 ```bash
@@ -196,6 +202,7 @@ Preview a Jira write before using `--allow-write`:
 - Markdown upload is a best-effort conversion to Confluence storage HTML. Prefer it for common text-first pages, not for macro-heavy round-trips.
 - `--body-file` and `--append-file` are for storage HTML files. Use `--body-markdown-file` or `--append-markdown-file` for Markdown inputs.
 - `replace-section` currently works best on text-first pages with clear heading structure. It intentionally fails when the target heading is missing or ambiguous.
+- `insert-after-heading` uses the same heading matching rule as `replace-section`, so it should target a heading that exists exactly once on the page.
 
 ## Local setup
 

--- a/src/conjira_cli/cli.py
+++ b/src/conjira_cli/cli.py
@@ -23,7 +23,11 @@ from conjira_cli.config import (
 from conjira_cli.inline_comments import render_inline_comment_summary_markdown
 from conjira_cli.markdown_export import MarkdownExporter
 from conjira_cli.markdown_import import markdown_to_storage_html
-from conjira_cli.section_edit import SectionEditError, replace_section_html
+from conjira_cli.section_edit import (
+    SectionEditError,
+    insert_after_heading_html,
+    replace_section_html,
+)
 from conjira_cli.tree_export import export_page_tree, sanitize_path_component
 
 _JIRA_SUMMARY_FIELDS = [
@@ -402,6 +406,22 @@ def _build_parser() -> argparse.ArgumentParser:
     replace_section_body_group.add_argument("--section-markdown")
     replace_section_body_group.add_argument("--section-markdown-file")
 
+    insert_after_heading = subparsers.add_parser(
+        "insert-after-heading",
+        help="Insert content immediately after a specific Confluence heading",
+    )
+    insert_after_heading.add_argument("--page-id", required=True)
+    insert_after_heading.add_argument("--heading", required=True)
+    insert_after_heading.add_argument("--allow-write", action="store_true")
+    insert_after_heading.add_argument("--dry-run", action="store_true")
+    insert_after_heading_body_group = insert_after_heading.add_mutually_exclusive_group(
+        required=True
+    )
+    insert_after_heading_body_group.add_argument("--insert-html")
+    insert_after_heading_body_group.add_argument("--insert-file")
+    insert_after_heading_body_group.add_argument("--insert-markdown")
+    insert_after_heading_body_group.add_argument("--insert-markdown-file")
+
     move_page = subparsers.add_parser(
         "move-page",
         help="Move an existing Confluence page under a different parent page",
@@ -634,6 +654,31 @@ def _confluence_replace_section_preview(
     }
 
 
+def _confluence_insert_after_heading_preview(
+    *,
+    page: Dict[str, Any],
+    heading: str,
+    result: Any,
+    body_source: str,
+) -> Dict[str, Any]:
+    current_summary = ConfluenceClient.summarize_page(page)
+    return {
+        "dry_run": True,
+        "product": "confluence",
+        "action": "insert-after-heading",
+        "page_id": current_summary.get("id"),
+        "space_key": current_summary.get("space_key"),
+        "source_url": current_summary.get("webui_url"),
+        "heading": heading,
+        "matched_heading": result.matched_heading,
+        "heading_level": result.heading_level,
+        "body_source": body_source,
+        "inserted_after_heading": True,
+        "inserted_block_preview": _preview_html(result.inserted_html),
+        "resulting_body_preview": _preview_html(result.updated_body_html),
+    }
+
+
 def _confluence_move_page_preview(
     *,
     page: Dict[str, Any],
@@ -818,6 +863,11 @@ def _guidance_for_config_error(message: str) -> list[str]:
         return [
             "Check that the heading text exists exactly once on the live Confluence page before retrying replace-section.",
             "For the first iteration, replace-section is safest on text-first pages with clear heading structure.",
+        ]
+    if "insert-after-heading target heading" in lowered:
+        return [
+            "Check that the heading text exists exactly once on the live Confluence page before retrying insert-after-heading.",
+            "insert-after-heading is safest on text-first pages with clear heading structure and a stable target heading.",
         ]
     if "move-page requires different" in lowered:
         return [
@@ -1189,6 +1239,51 @@ def _handle_confluence(args: argparse.Namespace) -> Dict[str, Any]:
         payload["action"] = "replace-section"
         payload["heading"] = args.heading
         payload["matched_heading"] = replacement.matched_heading
+        return payload
+    if args.command == "insert-after-heading":
+        _require_write_intent(args.allow_write, args.dry_run)
+        _assert_confluence_update_allowed(
+            page_id=args.page_id,
+            allowed_page_ids=settings.allowed_page_ids,
+        )
+        inserted_html = _read_confluence_body_arg(
+            args.insert_html,
+            args.insert_file,
+            args.insert_markdown,
+            args.insert_markdown_file,
+            mermaid_macro_name=settings.mermaid_macro_name,
+        )
+        page = client.get_page(args.page_id, expand="body.storage,version,space")
+        current_body = (((page.get("body") or {}).get("storage") or {}).get("value")) or ""
+        try:
+            insertion = insert_after_heading_html(
+                current_body,
+                heading=args.heading,
+                inserted_html=inserted_html,
+            )
+        except SectionEditError as exc:
+            raise ConfigError(str(exc)) from exc
+        body_source = _confluence_body_source(
+            raw_html=args.insert_html,
+            html_file=args.insert_file,
+            raw_markdown=args.insert_markdown,
+            markdown_file=args.insert_markdown_file,
+        )
+        if args.dry_run:
+            return _confluence_insert_after_heading_preview(
+                page=page,
+                heading=args.heading,
+                result=insertion,
+                body_source=body_source or "unknown",
+            )
+        updated = client.update_page_from_snapshot(
+            page,
+            new_body_html=insertion.updated_body_html,
+        )
+        payload = client.summarize_page(updated)
+        payload["action"] = "insert-after-heading"
+        payload["heading"] = args.heading
+        payload["matched_heading"] = insertion.matched_heading
         return payload
     if args.command == "move-page":
         _require_write_intent(args.allow_write, args.dry_run)

--- a/src/conjira_cli/section_edit.py
+++ b/src/conjira_cli/section_edit.py
@@ -27,6 +27,15 @@ class SectionReplacementResult:
     updated_body_html: str
 
 
+@dataclass
+class HeadingInsertionResult:
+    heading: str
+    matched_heading: str
+    heading_level: int
+    inserted_html: str
+    updated_body_html: str
+
+
 def replace_section_html(
     body_html: str,
     *,
@@ -35,29 +44,11 @@ def replace_section_html(
 ) -> SectionReplacementResult:
     root = _parse_fragment(body_html)
     children = list(root)
-    normalized_target = _normalize_heading(heading)
-
-    matches: list[tuple[int, ET.Element, int]] = []
-    for index, child in enumerate(children):
-        heading_level = _heading_level(child)
-        if heading_level is None:
-            continue
-        rendered_heading = _element_text(child)
-        if _normalize_heading(rendered_heading) == normalized_target:
-            matches.append((index, child, heading_level))
-
-    if not matches:
-        raise SectionEditError(
-            'replace-section target heading "{0}" was not found.'.format(heading)
-        )
-    if len(matches) > 1:
-        raise SectionEditError(
-            'replace-section target heading "{0}" is ambiguous because it appears multiple times.'.format(
-                heading
-            )
-        )
-
-    match_index, match_elem, match_level = matches[0]
+    match_index, match_elem, match_level = _find_unique_heading(
+        children,
+        heading=heading,
+        action_name="replace-section",
+    )
     end_index = len(children)
     for index in range(match_index + 1, len(children)):
         next_level = _heading_level(children[index])
@@ -87,6 +78,36 @@ def replace_section_html(
     )
 
 
+def insert_after_heading_html(
+    body_html: str,
+    *,
+    heading: str,
+    inserted_html: str,
+) -> HeadingInsertionResult:
+    root = _parse_fragment(body_html)
+    children = list(root)
+    match_index, match_elem, match_level = _find_unique_heading(
+        children,
+        heading=heading,
+        action_name="insert-after-heading",
+    )
+
+    new_root = _parse_fragment(inserted_html)
+    new_children = [copy.deepcopy(child) for child in list(new_root)]
+
+    insert_at = match_index + 1
+    for offset, child in enumerate(new_children):
+        root.insert(insert_at + offset, child)
+
+    return HeadingInsertionResult(
+        heading=heading,
+        matched_heading=_element_text(match_elem),
+        heading_level=match_level,
+        inserted_html=_serialize_elements(new_children),
+        updated_body_html=_serialize_root(root),
+    )
+
+
 def _parse_fragment(fragment_html: str) -> ET.Element:
     wrapped = _WRAPPED_ROOT_PREFIX + fragment_html + "</root>"
     try:
@@ -101,6 +122,36 @@ def _serialize_root(root: ET.Element) -> str:
 
 def _serialize_elements(elements: list[ET.Element]) -> str:
     return "".join(ET.tostring(element, encoding="unicode") for element in elements).strip()
+
+
+def _find_unique_heading(
+    children: list[ET.Element],
+    *,
+    heading: str,
+    action_name: str,
+) -> tuple[int, ET.Element, int]:
+    normalized_target = _normalize_heading(heading)
+    matches: list[tuple[int, ET.Element, int]] = []
+    for index, child in enumerate(children):
+        heading_level = _heading_level(child)
+        if heading_level is None:
+            continue
+        rendered_heading = _element_text(child)
+        if _normalize_heading(rendered_heading) == normalized_target:
+            matches.append((index, child, heading_level))
+
+    if not matches:
+        raise SectionEditError(
+            '{0} target heading "{1}" was not found.'.format(action_name, heading)
+        )
+    if len(matches) > 1:
+        raise SectionEditError(
+            '{0} target heading "{1}" is ambiguous because it appears multiple times.'.format(
+                action_name,
+                heading,
+            )
+        )
+    return matches[0]
 
 
 def _local_name(tag: str) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -570,6 +570,141 @@ class CliTests(unittest.TestCase):
         self.assertEqual(mock_update_page.call_args.args[0]["id"], "12345")
         self.assertIn("<p>Replacement</p>", mock_update_page.call_args.kwargs["new_body_html"])
 
+    def test_handle_confluence_insert_after_heading_dry_run_returns_preview(self) -> None:
+        args = SimpleNamespace(
+            command="insert-after-heading",
+            base_url=None,
+            token=None,
+            token_file=None,
+            token_keychain_service=None,
+            token_keychain_account=None,
+            timeout=None,
+            env_file=None,
+            page_id="12345",
+            heading="Install",
+            allow_write=False,
+            dry_run=True,
+            insert_html=None,
+            insert_file=None,
+            insert_markdown="Prepended install note",
+            insert_markdown_file=None,
+        )
+        settings = ConfluenceSettings(
+            base_url="https://confluence.example.com",
+            token="token",
+            timeout_seconds=30,
+        )
+        page = {
+            "id": "12345",
+            "type": "page",
+            "title": "Guide",
+            "space": {"key": "DOCS"},
+            "version": {"number": 7},
+            "body": {
+                "storage": {
+                    "value": (
+                        "<h1>Guide</h1>"
+                        "<h2>Install</h2>"
+                        "<p>Old step</p>"
+                        "<h2>Usage</h2>"
+                        "<p>Run command</p>"
+                    )
+                }
+            },
+            "_links": {
+                "base": "https://confluence.example.com",
+                "webui": "/pages/viewpage.action?pageId=12345",
+            },
+        }
+
+        with mock.patch("conjira_cli.cli.build_confluence_settings", return_value=settings), mock.patch(
+            "conjira_cli.cli.ConfluenceClient.get_page",
+            return_value=page,
+        ) as mock_get_page, mock.patch(
+            "conjira_cli.cli.ConfluenceClient.update_page_from_snapshot"
+        ) as mock_update_page:
+            payload = _handle_confluence(args)
+
+        self.assertTrue(payload["dry_run"])
+        self.assertEqual(payload["action"], "insert-after-heading")
+        self.assertEqual(payload["page_id"], "12345")
+        self.assertEqual(payload["heading"], "Install")
+        self.assertEqual(payload["matched_heading"], "Install")
+        self.assertEqual(payload["body_source"], "markdown")
+        self.assertIn("Prepended install note", payload["inserted_block_preview"])
+        mock_get_page.assert_called_once_with("12345", expand="body.storage,version,space")
+        mock_update_page.assert_not_called()
+
+    def test_handle_confluence_insert_after_heading_write_updates_page(self) -> None:
+        args = SimpleNamespace(
+            command="insert-after-heading",
+            base_url=None,
+            token=None,
+            token_file=None,
+            token_keychain_service=None,
+            token_keychain_account=None,
+            timeout=None,
+            env_file=None,
+            page_id="12345",
+            heading="Install",
+            allow_write=True,
+            dry_run=False,
+            insert_html="<p>Inserted</p>",
+            insert_file=None,
+            insert_markdown=None,
+            insert_markdown_file=None,
+        )
+        settings = ConfluenceSettings(
+            base_url="https://confluence.example.com",
+            token="token",
+            timeout_seconds=30,
+        )
+        page = {
+            "id": "12345",
+            "type": "page",
+            "title": "Guide",
+            "space": {"key": "DOCS"},
+            "version": {"number": 7},
+            "body": {
+                "storage": {
+                    "value": "<h2>Install</h2><p>Old step</p><h2>Usage</h2><p>Run command</p>"
+                }
+            },
+            "_links": {
+                "base": "https://confluence.example.com",
+                "webui": "/pages/viewpage.action?pageId=12345",
+            },
+        }
+        updated_summary = {
+            "id": "12345",
+            "type": "page",
+            "status": "current",
+            "title": "Guide",
+            "space": {"key": "DOCS"},
+            "version": {"number": 8},
+            "_links": {
+                "base": "https://confluence.example.com",
+                "webui": "/pages/viewpage.action?pageId=12345",
+            },
+        }
+
+        with mock.patch("conjira_cli.cli.build_confluence_settings", return_value=settings), mock.patch(
+            "conjira_cli.cli.ConfluenceClient.get_page",
+            return_value=page,
+        ) as mock_get_page, mock.patch(
+            "conjira_cli.cli.ConfluenceClient.update_page_from_snapshot",
+            return_value=updated_summary,
+        ) as mock_update_page:
+            payload = _handle_confluence(args)
+
+        self.assertEqual(payload["action"], "insert-after-heading")
+        self.assertEqual(payload["heading"], "Install")
+        self.assertEqual(payload["matched_heading"], "Install")
+        mock_get_page.assert_called_once_with("12345", expand="body.storage,version,space")
+        mock_update_page.assert_called_once()
+        self.assertEqual(mock_update_page.call_args.args[0]["id"], "12345")
+        self.assertIn("<h2>Install</h2><p>Inserted</p><p>Old step</p>", mock_update_page.call_args.kwargs["new_body_html"])
+
     def test_handle_confluence_move_page_dry_run_returns_preview(self) -> None:
         args = SimpleNamespace(
             command="move-page",
@@ -690,6 +825,14 @@ class CliTests(unittest.TestCase):
 
         self.assertEqual(payload["error_type"], "ConfigError")
         self.assertTrue(any("heading" in item.lower() for item in payload["guidance"]))
+
+    def test_build_error_payload_adds_insert_after_heading_guidance(self) -> None:
+        payload = _build_error_payload(
+            ConfigError('insert-after-heading target heading "Install" was not found.')
+        )
+
+        self.assertEqual(payload["error_type"], "ConfigError")
+        self.assertTrue(any("insert-after-heading" in item.lower() for item in payload["guidance"]))
 
     def test_build_error_payload_adds_move_page_guidance(self) -> None:
         payload = _build_error_payload(

--- a/tests/test_section_edit.py
+++ b/tests/test_section_edit.py
@@ -1,6 +1,10 @@
 import unittest
 
-from conjira_cli.section_edit import SectionEditError, replace_section_html
+from conjira_cli.section_edit import (
+    SectionEditError,
+    insert_after_heading_html,
+    replace_section_html,
+)
 
 
 class SectionEditTests(unittest.TestCase):
@@ -45,4 +49,45 @@ class SectionEditTests(unittest.TestCase):
                 "<h2>Install</h2><p>A</p><h2>Install</h2><p>B</p>",
                 heading="Install",
                 replacement_html="<p>Replacement</p>",
+            )
+
+    def test_insert_after_heading_html_inserts_immediately_after_heading(self) -> None:
+        body_html = (
+            "<h1>Guide</h1>"
+            "<p>Intro</p>"
+            "<h2>Install</h2>"
+            "<p>Old install step</p>"
+            "<h2>Usage</h2>"
+            "<p>Run command</p>"
+        )
+
+        result = insert_after_heading_html(
+            body_html,
+            heading="Install",
+            inserted_html="<p>New note</p><ul><li>Check this first</li></ul>",
+        )
+
+        self.assertEqual(result.matched_heading, "Install")
+        self.assertEqual(result.heading_level, 2)
+        self.assertIn("<p>New note</p>", result.inserted_html)
+        self.assertIn("<ul><li>Check this first</li></ul>", result.updated_body_html)
+        self.assertIn(
+            "<h2>Install</h2><p>New note</p><ul><li>Check this first</li></ul><p>Old install step</p>",
+            result.updated_body_html,
+        )
+
+    def test_insert_after_heading_html_fails_when_heading_missing(self) -> None:
+        with self.assertRaises(SectionEditError):
+            insert_after_heading_html(
+                "<h1>Guide</h1><p>Body</p>",
+                heading="Install",
+                inserted_html="<p>Inserted</p>",
+            )
+
+    def test_insert_after_heading_html_fails_when_heading_ambiguous(self) -> None:
+        with self.assertRaises(SectionEditError):
+            insert_after_heading_html(
+                "<h2>Install</h2><p>A</p><h2>Install</h2><p>B</p>",
+                heading="Install",
+                inserted_html="<p>Inserted</p>",
             )


### PR DESCRIPTION
## Summary
- add a new `insert-after-heading` Confluence command for safer partial page edits
- share unique heading matching logic with `replace-section` so missing or ambiguous targets fail fast
- add dry-run preview output, tests, and docs examples for the new workflow

## Why
`update-page` already supports full-body replacement and append flows, but users also need a safer way to insert content into the middle of long Confluence pages without rewriting the entire document manually. This adds a small MCP-style partial-edit step while keeping the final Confluence write as the normal full-body update.

## Validation
- `PYTHONPATH=src python3 -m unittest discover -s tests -v`
- `python3 -m compileall src`

## Notes
This is another narrow iteration for issue #14. It does not add server-side patch semantics; it fetches the current page, applies the insertion locally, previews with `--dry-run`, and then writes the updated full body.