### PR TITLE
Fix XHTML strict violations and nested table pipe escaping

### DIFF
--- a/src/conjira_cli/client.py
+++ b/src/conjira_cli/client.py
@@ -40,7 +40,8 @@ def validate_storage_html(body_html: str) -> None:
     a cryptic 400 from the server.
     """
     wrapped = (
-        '<root xmlns:ac="urn:ac" xmlns:ri="urn:ri">'
+        '<root xmlns:ac="urn:ac" xmlns:ri="urn:ri"'
+        ' xmlns:atlassian="urn:atlassian">'
         + body_html
         + "</root>"
     )

--- a/src/conjira_cli/client.py
+++ b/src/conjira_cli/client.py
@@ -5,6 +5,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+import xml.etree.ElementTree as ET
 from typing import Any, Dict, Iterable, Optional
 
 from conjira_cli.inline_comments import build_inline_comment_summary
@@ -29,6 +30,27 @@ class ConfluenceError(AtlassianError):
 
 class JiraError(AtlassianError):
     pass
+
+
+def validate_storage_html(body_html: str) -> None:
+    """Check that *body_html* is well-formed XHTML before sending to Confluence.
+
+    Raises :class:`ConfluenceError` with a descriptive message if parsing
+    fails, giving the caller a chance to fix the content instead of getting
+    a cryptic 400 from the server.
+    """
+    wrapped = (
+        '<root xmlns:ac="urn:ac" xmlns:ri="urn:ri">'
+        + body_html
+        + "</root>"
+    )
+    try:
+        ET.fromstring(wrapped)
+    except ET.ParseError as exc:
+        raise ConfluenceError(
+            f"Body HTML is not well-formed XHTML — Confluence will reject it. "
+            f"Detail: {exc}",
+        ) from exc
 
 
 class BaseAtlassianClient:
@@ -168,6 +190,7 @@ class ConfluenceClient(BaseAtlassianClient):
         body_html: str,
         parent_id: Optional[str] = None,
     ) -> Dict[str, Any]:
+        validate_storage_html(body_html)
         payload: Dict[str, Any] = {
             "type": "page",
             "title": title,
@@ -214,6 +237,8 @@ class ConfluenceClient(BaseAtlassianClient):
         updated_body = new_body_html if new_body_html is not None else current_body
         if append_html:
             updated_body += append_html
+
+        validate_storage_html(updated_body)
 
         payload = {
             "id": current["id"],

--- a/src/conjira_cli/markdown_export.py
+++ b/src/conjira_cli/markdown_export.py
@@ -470,16 +470,25 @@ class MarkdownExporter:
             child_name = _local_name(child.tag)
             if child_name in {"ul", "ol"}:
                 list_text = self._render_block(child, indent=0).strip().replace("\n", "<br>")
+                # Escape pipes BEFORE joining so nested content doesn't
+                # break the outer table column boundaries.
+                list_text = list_text.replace("|", "\\|")
                 pieces.append(list_text)
             elif child_name == "table":
                 table_text = self._render_table(child).replace("\n", "<br>")
+                # Escape pipes from the nested table so they don't create
+                # spurious columns in the parent table row.
+                table_text = table_text.replace("|", "\\|")
                 pieces.append(table_text)
             else:
                 pieces.append(self._render_inline(child))
             if child.tail and _collapse_inline(child.tail):
                 pieces.append(_collapse_inline(child.tail))
         joined = _join_inline_pieces(pieces)
-        joined = joined.replace("|", "\\|")
+        # Escape any remaining unescaped pipes from inline content.
+        # Use a negative lookbehind to avoid double-escaping pipes that
+        # were already escaped above.
+        joined = re.sub(r"(?<!\\)\|", r"\\|", joined)
         joined = joined.replace("\n", "<br>")
         joined = re.sub(r"\s{2,}", " ", joined)
         joined = re.sub(r"^(<br>\s*)+$", "", joined)

--- a/src/conjira_cli/markdown_export.py
+++ b/src/conjira_cli/markdown_export.py
@@ -470,15 +470,17 @@ class MarkdownExporter:
             child_name = _local_name(child.tag)
             if child_name in {"ul", "ol"}:
                 list_text = self._render_block(child, indent=0).strip().replace("\n", "<br>")
-                # Escape pipes BEFORE joining so nested content doesn't
-                # break the outer table column boundaries.
-                list_text = list_text.replace("|", "\\|")
+                # Escape unescaped pipes BEFORE joining so nested content
+                # doesn't break the outer table column boundaries.
+                # Use negative lookbehind to avoid double-escaping pipes
+                # that were already escaped by deeper recursion.
+                list_text = re.sub(r"(?<!\\)\|", r"\\|", list_text)
                 pieces.append(list_text)
             elif child_name == "table":
                 table_text = self._render_table(child).replace("\n", "<br>")
-                # Escape pipes from the nested table so they don't create
-                # spurious columns in the parent table row.
-                table_text = table_text.replace("|", "\\|")
+                # Escape unescaped pipes from the nested table so they
+                # don't create spurious columns in the parent table row.
+                table_text = re.sub(r"(?<!\\)\|", r"\\|", table_text)
                 pieces.append(table_text)
             else:
                 pieces.append(self._render_inline(child))

--- a/src/conjira_cli/markdown_import.py
+++ b/src/conjira_cli/markdown_import.py
@@ -39,7 +39,33 @@ def markdown_to_storage_html(
     markdown = _strip_frontmatter(markdown).replace("\r\n", "\n").replace("\r", "\n")
     lines = markdown.split("\n")
     html_parts, _ = _parse_blocks(lines, 0, mermaid_macro_name=mermaid_macro_name)
-    return "".join(html_parts).strip()
+    result = "".join(html_parts).strip()
+    return _ensure_xhtml_self_closing(result)
+
+
+# Tags that must be self-closing in Confluence XHTML Storage Format
+_VOID_TAGS = {"br", "hr", "img"}
+_VOID_TAG_RE = re.compile(
+    r"<(" + "|".join(_VOID_TAGS) + r")((?:\s[^>]*?)?)(\s*/?)>",
+    re.IGNORECASE,
+)
+
+
+def _ensure_xhtml_self_closing(html_str: str) -> str:
+    """Normalise void HTML tags to XHTML self-closing form.
+
+    Confluence Storage Format requires strict XHTML: ``<br />`` not ``<br>``.
+    Handles ``<br>``, ``<br/>``, ``<br />``, and variants with attributes.
+    """
+    def _fix(m: re.Match[str]) -> str:
+        tag = m.group(1)
+        attrs = (m.group(2) or "").rstrip()
+        # Strip any trailing slash already present in attrs
+        if attrs.endswith("/"):
+            attrs = attrs[:-1].rstrip()
+        return f"<{tag}{attrs} />"
+
+    return _VOID_TAG_RE.sub(_fix, html_str)
 
 
 def _strip_frontmatter(markdown: str) -> str:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -213,3 +213,20 @@ class ValidateStorageHtmlTests(unittest.TestCase):
 
         with self.assertRaises(ConfluenceError):
             validate_storage_html("<p>line<br>break</p>")
+
+    def test_valid_xhtml_with_confluence_macros_passes(self) -> None:
+        from conjira_cli.client import validate_storage_html
+
+        validate_storage_html(
+            '<ac:structured-macro ac:name="code" ac:schema-version="1">'
+            '<ac:parameter ac:name="language">python</ac:parameter>'
+            '<ac:plain-text-body><![CDATA[print("hi")]]></ac:plain-text-body>'
+            "</ac:structured-macro>"
+        )
+
+    def test_valid_xhtml_with_atlassian_namespace_passes(self) -> None:
+        from conjira_cli.client import validate_storage_html
+
+        validate_storage_html(
+            '<td atlassian:data-highlight-colour="blue">text</td>'
+        )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -192,3 +192,24 @@ class ClientTests(unittest.TestCase):
 
         self.assertEqual([page["id"] for page in pages], ["1", "2", "3"])
         self.assertEqual(mock_get_child_pages.call_count, 2)
+
+
+class ValidateStorageHtmlTests(unittest.TestCase):
+    def test_valid_xhtml_passes(self) -> None:
+        from conjira_cli.client import validate_storage_html
+
+        # Should not raise
+        validate_storage_html("<p>Hello <strong>world</strong></p>")
+
+    def test_invalid_xhtml_raises(self) -> None:
+        from conjira_cli.client import validate_storage_html, ConfluenceError
+
+        with self.assertRaises(ConfluenceError) as ctx:
+            validate_storage_html("<p>Unclosed paragraph")
+        self.assertIn("well-formed XHTML", str(ctx.exception))
+
+    def test_bare_br_is_invalid(self) -> None:
+        from conjira_cli.client import validate_storage_html, ConfluenceError
+
+        with self.assertRaises(ConfluenceError):
+            validate_storage_html("<p>line<br>break</p>")

--- a/tests/test_markdown_export.py
+++ b/tests/test_markdown_export.py
@@ -249,3 +249,49 @@ class MarkdownExportTests(unittest.TestCase):
         result = exporter.convert_fragment(html)
 
         self.assertIn("- Description emphasis", result)
+
+    def test_nested_table_pipes_escaped_in_cell(self) -> None:
+        """A nested table inside a cell must not break the outer table columns."""
+        exporter = MarkdownExporter(base_url="https://confluence.example.com", page_id="123")
+        # Outer 2-column table with headers that do NOT trigger structured
+        # detection so we get a regular pipe table.
+        html = (
+            "<table><tbody>"
+            "<tr><th>Host</th><th>Config</th></tr>"
+            "<tr>"
+            "<td>SSL cert</td>"
+            "<td><table><tbody>"
+            "<tr><td>Type</td><td>Wildcard</td></tr>"
+            "<tr><td>Issuer</td><td>DigiCert</td></tr>"
+            "</tbody></table></td>"
+            "</tr>"
+            "</tbody></table>"
+        )
+        result = exporter.convert_fragment(html)
+
+        # The outer table row for "SSL cert" should have nested table pipes
+        # escaped so it stays as a 2-column row.
+        for line in result.splitlines():
+            if "SSL cert" in line and line.strip().startswith("|"):
+                self.assertIn("\\|", line, "Nested table pipes should be escaped")
+                break
+        else:
+            self.fail("Could not find 'SSL cert' row in rendered table")
+
+    def test_nested_list_pipes_escaped_in_cell(self) -> None:
+        """A nested list with pipe chars inside a cell must escape them."""
+        exporter = MarkdownExporter(base_url="https://confluence.example.com", page_id="123")
+        html = (
+            "<table><tbody>"
+            "<tr><th>Task</th><th>Notes</th></tr>"
+            "<tr>"
+            "<td>Review</td>"
+            "<td><ul><li>Option A | Option B</li></ul></td>"
+            "</tr>"
+            "</tbody></table>"
+        )
+        result = exporter.convert_fragment(html)
+
+        for line in result.splitlines():
+            if "Review" in line and line.strip().startswith("|"):
+                self.assertIn("\\|", line, "Pipe in list item should be escaped")

--- a/tests/test_markdown_import.py
+++ b/tests/test_markdown_import.py
@@ -153,3 +153,37 @@ class MarkdownImportTests(unittest.TestCase):
         self.assertIn('<ac:structured-macro ac:name="status"', result)
         self.assertIn('<ac:parameter ac:name="colour">Blue</ac:parameter>', result)
         self.assertIn('<ac:parameter ac:name="title">Planned</ac:parameter>', result)
+
+    def test_xhtml_self_closing_br_tags(self) -> None:
+        """<br> must be emitted as <br /> for Confluence XHTML strict mode."""
+        # The current renderer doesn't emit bare <br> from markdown, but
+        # if inline HTML sneaks through we need the post-processor to fix it.
+        from conjira_cli.markdown_import import _ensure_xhtml_self_closing
+
+        self.assertEqual(_ensure_xhtml_self_closing("<br>"), "<br />")
+        self.assertEqual(_ensure_xhtml_self_closing("<br/>"), "<br />")
+        self.assertEqual(_ensure_xhtml_self_closing("<br />"), "<br />")
+        self.assertEqual(_ensure_xhtml_self_closing("<hr>"), "<hr />")
+        self.assertEqual(
+            _ensure_xhtml_self_closing("<p>text<br>more</p>"),
+            "<p>text<br />more</p>",
+        )
+
+    def test_xhtml_self_closing_preserves_attributes(self) -> None:
+        from conjira_cli.markdown_import import _ensure_xhtml_self_closing
+
+        self.assertEqual(
+            _ensure_xhtml_self_closing('<hr class="divider">'),
+            '<hr class="divider" />',
+        )
+
+    def test_output_is_valid_xhtml(self) -> None:
+        """Full markdown-to-HTML output must be well-formed XHTML."""
+        import xml.etree.ElementTree as ET
+
+        result = markdown_to_storage_html(
+            "# Hello\n\nParagraph with **bold**.\n\n---\n"
+        )
+        wrapped = f'<root xmlns:ac="urn:ac" xmlns:ri="urn:ri">{result}</root>'
+        # Should not raise
+        ET.fromstring(wrapped)

--- a/tests/test_markdown_import.py
+++ b/tests/test_markdown_import.py
@@ -177,6 +177,14 @@ class MarkdownImportTests(unittest.TestCase):
             '<hr class="divider" />',
         )
 
+    def test_xhtml_self_closing_img_tag(self) -> None:
+        from conjira_cli.markdown_import import _ensure_xhtml_self_closing
+
+        self.assertEqual(
+            _ensure_xhtml_self_closing('<img src="x.png">'),
+            '<img src="x.png" />',
+        )
+
     def test_output_is_valid_xhtml(self) -> None:
         """Full markdown-to-HTML output must be well-formed XHTML."""
         import xml.etree.ElementTree as ET


### PR DESCRIPTION
## Summary

- **XHTML self-closing tags**: `markdown_import.py` now post-processes output to normalise `<br>`, `<br/>`, `<hr>`, `<img>` to proper XHTML self-closing form (`<br />`). Confluence Storage Format requires strict XHTML and rejects non-compliant tags.
- **Nested table pipe escaping**: `markdown_export.py` now escapes `|` from nested tables and lists *before* joining with the outer cell content, preventing spurious column splits (e.g. a nested 2-col table inside a cell no longer blows the outer row to 17 columns).
- **Pre-flight XHTML validation**: `client.py` now validates body HTML via `xml.etree.ElementTree.fromstring()` before sending to the Confluence API, giving a clear local error instead of a cryptic 400 from the server.

## Test plan

- [x] 101 existing + new unit tests pass
- [ ] Manual: export a page with nested tables, verify pipe escaping
- [ ] Manual: create/update a page with `<br>` in markdown, verify no XHTML rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)