### PR TITLE
Document Windows Credential Manager setup

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -231,7 +231,33 @@ security add-generic-password -U -s conjira-cli -a jira-prod -w "$PAT"
 unset PAT
 ```
 
-Linux나 Windows에서는 Keychain 대신 환경변수나 token file을 쓰면 됩니다.
+Windows에서는 Keychain 대신 Windows Credential Manager에 PAT를 저장하고, 실행 직전에 현재 PowerShell 세션의 환경변수로만 주입하는 방식을 권장합니다. `local/agent.env`에는 base URL과 export 경로 같은 비밀이 아닌 값만 두고, `CONFLUENCE_PAT_KEYCHAIN_*`, `JIRA_PAT_KEYCHAIN_*` 항목은 제거하거나 주석 처리합니다.
+
+처음 한 번만 PowerShell에서 `CredentialManager` 모듈을 준비하고 PAT를 저장합니다.
+
+```powershell
+Install-Module CredentialManager -Scope CurrentUser
+
+$cred = Get-Credential -UserName confluence-prod -Message "Enter Confluence PAT as password"
+New-StoredCredential -Target "conjira-cli/confluence-prod" -UserName $cred.UserName -Password $cred.GetNetworkCredential().Password -Persist LocalMachine
+Remove-Variable cred
+
+$cred = Get-Credential -UserName jira-prod -Message "Enter Jira PAT as password"
+New-StoredCredential -Target "conjira-cli/jira-prod" -UserName $cred.UserName -Password $cred.GetNetworkCredential().Password -Persist LocalMachine
+Remove-Variable cred
+```
+
+이후 `conjira`를 실행할 때마다 필요한 세션에서 Credential Manager 값을 환경변수로 읽어옵니다. 이 값은 현재 PowerShell 세션에만 남습니다.
+
+```powershell
+$env:CONFLUENCE_PAT = (Get-StoredCredential -Target "conjira-cli/confluence-prod").GetNetworkCredential().Password
+$env:JIRA_PAT = (Get-StoredCredential -Target "conjira-cli/jira-prod").GetNetworkCredential().Password
+
+conjira --env-file .\local\agent.env auth-check
+conjira --env-file .\local\agent.env jira-auth-check
+```
+
+Windows Credential Manager를 쓰기 어렵거나 Linux 환경이라면 환경변수나 token file을 사용하면 됩니다.
 
 ```dotenv
 CONFLUENCE_BASE_URL=https://confluence.example.com

--- a/README.md
+++ b/README.md
@@ -231,7 +231,33 @@ security add-generic-password -U -s conjira-cli -a jira-prod -w "$PAT"
 unset PAT
 ```
 
-On Linux or Windows, use environment variables or token files instead of Keychain. For example:
+On Windows, use Windows Credential Manager as the closest Keychain-style path. Keep `local/agent.env` non-secret, remove or comment out `CONFLUENCE_PAT_KEYCHAIN_*` and `JIRA_PAT_KEYCHAIN_*`, then load PATs into the current PowerShell session right before running `conjira`.
+
+Set up the PowerShell `CredentialManager` module and store the PATs once:
+
+```powershell
+Install-Module CredentialManager -Scope CurrentUser
+
+$cred = Get-Credential -UserName confluence-prod -Message "Enter Confluence PAT as password"
+New-StoredCredential -Target "conjira-cli/confluence-prod" -UserName $cred.UserName -Password $cred.GetNetworkCredential().Password -Persist LocalMachine
+Remove-Variable cred
+
+$cred = Get-Credential -UserName jira-prod -Message "Enter Jira PAT as password"
+New-StoredCredential -Target "conjira-cli/jira-prod" -UserName $cred.UserName -Password $cred.GetNetworkCredential().Password -Persist LocalMachine
+Remove-Variable cred
+```
+
+Before running the CLI in a new PowerShell session, read those credentials into environment variables. The values only live in that session:
+
+```powershell
+$env:CONFLUENCE_PAT = (Get-StoredCredential -Target "conjira-cli/confluence-prod").GetNetworkCredential().Password
+$env:JIRA_PAT = (Get-StoredCredential -Target "conjira-cli/jira-prod").GetNetworkCredential().Password
+
+conjira --env-file .\local\agent.env auth-check
+conjira --env-file .\local\agent.env jira-auth-check
+```
+
+If Windows Credential Manager is unavailable, or on Linux, use environment variables or token files instead. For example:
 
 ```dotenv
 CONFLUENCE_BASE_URL=https://confluence.example.com

--- a/docs/AGENT_USAGE.md
+++ b/docs/AGENT_USAGE.md
@@ -24,7 +24,7 @@ The `local/agent.env` file is intentionally gitignored. It stores machine-specif
 
 The actual PAT should stay in a local secret store when possible, not in chat, not in source code, and not in tracked `.env` files.
 
-On macOS, Keychain is the recommended local path. On Linux or Windows, prefer environment variables or token files.
+On macOS, Keychain is the recommended local path. On Windows, prefer Windows Credential Manager and load PATs into the current PowerShell session before running the CLI. On Linux, prefer environment variables or token files.
 
 The preferred storage policy is:
 
@@ -231,7 +231,28 @@ security add-generic-password -U -s conjira-cli -a jira-prod -w "$PAT"
 unset PAT
 ```
 
-If Keychain is not available, store PATs in env vars or token files instead:
+On Windows, store PATs in Windows Credential Manager and expose them only to the current PowerShell session before running the CLI. Remove or comment out `CONFLUENCE_PAT_KEYCHAIN_*` and `JIRA_PAT_KEYCHAIN_*` in `local/agent.env` so the CLI does not try the macOS Keychain path first.
+
+```powershell
+Install-Module CredentialManager -Scope CurrentUser
+
+$cred = Get-Credential -UserName confluence-prod -Message "Enter Confluence PAT as password"
+New-StoredCredential -Target "conjira-cli/confluence-prod" -UserName $cred.UserName -Password $cred.GetNetworkCredential().Password -Persist LocalMachine
+Remove-Variable cred
+
+$cred = Get-Credential -UserName jira-prod -Message "Enter Jira PAT as password"
+New-StoredCredential -Target "conjira-cli/jira-prod" -UserName $cred.UserName -Password $cred.GetNetworkCredential().Password -Persist LocalMachine
+Remove-Variable cred
+```
+
+Then load the PATs for the current session:
+
+```powershell
+$env:CONFLUENCE_PAT = (Get-StoredCredential -Target "conjira-cli/confluence-prod").GetNetworkCredential().Password
+$env:JIRA_PAT = (Get-StoredCredential -Target "conjira-cli/jira-prod").GetNetworkCredential().Password
+```
+
+If Keychain or Windows Credential Manager is not available, store PATs in env vars or token files instead:
 
 ```dotenv
 CONFLUENCE_BASE_URL=https://confluence.example.com

--- a/local/agent.env.example
+++ b/local/agent.env.example
@@ -3,6 +3,8 @@
 # From a source checkout before install, you can also run:
 #   bash scripts/setup-conjira-macos.sh
 # The setup script stores PATs in Keychain and writes only non-secret settings here.
+# On Windows, comment out the *_PAT_KEYCHAIN_* lines and load CONFLUENCE_PAT/JIRA_PAT
+# from Windows Credential Manager in the current PowerShell session before running conjira.
 
 CONFLUENCE_BASE_URL=https://confluence.example.com
 CONFLUENCE_PAT_KEYCHAIN_SERVICE=conjira-cli


### PR DESCRIPTION
## Summary

- Add Windows Credential Manager guidance as the Keychain alternative for PAT storage.
- Document the PowerShell flow for loading PATs into session-scoped environment variables.
- Note that macOS Keychain env keys should be removed or commented out on Windows.

## Validation

- Ran `git diff --cached --check` before committing.

## Scope

This PR intentionally includes only the Windows credential documentation changes. Existing local code/test edits were left unstaged.